### PR TITLE
TLSNSSLError exceptions

### DIFF
--- a/src/shared/tlsn_ssl.py
+++ b/src/shared/tlsn_ssl.py
@@ -66,6 +66,17 @@ tlsn_cipher_suites =  {47:['AES128',20,20,16,16,16,16],\
 for v in tlsn_cipher_suites.values():
     v.append(sum(v[1:]))
 
+class TLSNSSLError(Exception):
+    def __init__(self, msg, data=None):
+        self.msg = msg
+        if data:
+            self.data = binascii.hexlify(data)
+        else:
+            self.data = ''
+    
+    def __str__(self):
+        return self.msg + ': ' + self.data
+    
 def tls_record_decoder(d):
     '''Given a binary data stream d,
     separate it into TLS records and return
@@ -85,10 +96,12 @@ def tls_record_decoder(d):
             remaining = d
             break
         ver = d[1:3]
-        assert ver in tls_versions, "Incompatible TLS version"
+        if ver not in tls_versions: 
+            raise TLSNSSLError("Incompatible TLS version",ver)
         l = ba2int(d[3:5])
         if len(d) < l+5:
-            raise Exception("incomplete TLS record")
+            #can vandalise console, but not stored anywhere else, so needed.
+            raise TLSNSSLError("incomplete TLS record",d)
         fragment = d[5:5+l]
         d = d[5+l:]
         records.append(TLSRecord(rt, tlsver=ver, f=fragment))        
@@ -106,13 +119,15 @@ def tls_record_fragment_decoder(t,d, conn=None, ignore_mac = False):
             validity, plaintext, mac = conn.dtvm(d,t,return_mac=True)
         else:
             validity,plaintext = conn.dtvm(d,t)
-        if not validity and not ignore_mac: raise Exception ("Mac failure")
+            if not validity:
+                raise TLSNSSLError("Mac failure", plaintext[:10])
     else:
         plaintext = d
         
     while len(plaintext):
         if t == hs:
-            assert plaintext[0] in hs_type_map.keys(), "Invalid handshake type"
+            if not plaintext[0] in hs_type_map.keys():
+                raise TLSNSSLError("Invalid handshake type",plaintext[0])
             constructed_obj = hs_type_map[plaintext[0]](serialized=plaintext)
         elif t == appd:
             constructed_obj = TLSAppData(serialized=plaintext)
@@ -121,7 +136,7 @@ def tls_record_fragment_decoder(t,d, conn=None, ignore_mac = False):
         elif t == chcis:
             constructed_obj   = TLSChangeCipherSpec(serialized=plaintext)
         else:
-            raise ValueError("Invalid record type")
+            raise TLSNSSLError("Invalid record type",t)
         hlpos.append(constructed_obj)
         plaintext = constructed_obj.discarded
         
@@ -144,8 +159,10 @@ class TLSRecord(object):
     
     def serialize(self):
         check_contents = self.content_type and self.content_version and self.length and self.fragment
-        assert check_contents, "Cannot serialize record, data incomplete"
-        assert len(self.fragment) == self.length, "Incorrect record length"
+        if not check_contents:
+            raise TLSNSSLError("Cannot serialize record, data incomplete", self.fragment)
+        if not len(self.fragment) == self.length:
+            raise TLSNSSLError("Incorrect record length",self.fragment)
         self.serialized =  self.content_type + self. content_version + bi2ba(self.length,fixed=2) \
             + self.fragment      
 
@@ -154,12 +171,13 @@ class TLSHandshake(object):
         self.handshake_type = handshake_type
         if serialized:
             self.serialized = serialized
-            assert self.handshake_type == self.serialized[0], "Mismatched handshake type"
-            assert self.handshake_type in [h_ch,h_sh,h_shd,h_cert,h_cke,h_fin],\
-                   'Unrecognized or unimplemented handshake type'
+            if not self.handshake_type == self.serialized[0]:
+                raise TLSNSSLError("Mismatched handshake type",self.handshake_type+self.serialized[0])
+            if not self.handshake_type in [h_ch,h_sh,h_shd,h_cert,h_cke,h_fin]:
+                raise TLSNSSLError('Unrecognized or unimplemented handshake type',self.handshake_type)
             self.handshake_record_length = ba2int(self.serialized[1:4])
             if len(self.serialized[4:]) < self.handshake_record_length:
-                raise Exception ('Invalid handshake message length')
+                raise TLSNSSLError('Invalid handshake message length',self.serialized[1:4])
             self.discarded = self.serialized[4+self.handshake_record_length:]
             if self.discarded:
                 print ('Info: got a discarded data when constructing',
@@ -176,104 +194,101 @@ class TLSHandshake(object):
 
 class TLSClientHello(TLSHandshake):
     def __init__(self,serialized = None,client_random = None, cipher_suites=tlsn_cipher_suites.keys(), tlsver=None):
-        if serialized:
-            print ('Not implemented instantiation of client hello', 
-                   'with serialization; this is a client-only',
-                   ' TLS implementation')
-        else:
-            if client_random:
-                self.client_random = client_random
-            else: 
-                cr_time = bi2ba(int(time.time()))
-                self.client_random = cr_time + os.urandom(28)
-            #last byte is session id length
-            self.tlsver = tlsver
-            self.serialized = self.tlsver + self.client_random + '\x00' 
-            self.cipher_suites = cipher_suites
-            self.serialized += '\x00'+chr(2*len(self.cipher_suites))
-            for a in self.cipher_suites:
-                self.serialized += '\x00'+chr(a)                        
-            self.serialized += '\x01\x00' #compression methods - null only 
-            super(TLSClientHello,self).__init__(None, h_ch)
-            super(TLSClientHello,self).serialize()
+        assert not serialized, """Not implemented instantiation of client hello 
+                                   with serialization; this is a client-only
+                                   TLS implementation"""
+        if client_random:
+            self.client_random = client_random
+        else: 
+            cr_time = bi2ba(int(time.time()))
+            self.client_random = cr_time + os.urandom(28)
+        #last byte is session id length
+        self.tlsver = tlsver
+        self.serialized = self.tlsver + self.client_random + '\x00' 
+        self.cipher_suites = cipher_suites
+        self.serialized += '\x00'+chr(2*len(self.cipher_suites))
+        for a in self.cipher_suites:
+            self.serialized += '\x00'+chr(a)                        
+        self.serialized += '\x01\x00' #compression methods - null only 
+        super(TLSClientHello,self).__init__(None, h_ch)
+        super(TLSClientHello,self).serialize()
         
         
 class TLSServerHello(TLSHandshake):
     def __init__(self,serialized = None,server_random = None, cipher_suite=None):
-        if serialized:
-            super(TLSServerHello,self).__init__(serialized,h_sh)
-            self.tlsver = self.serialized[4:6]
-            self.server_random = self.serialized[6:38]
-            self.session_id_length = ba2int(self.serialized[38])
-            if self.session_id_length != 0:
-                assert self.session_id_length == 32, \
-                       'Server hello contains unrecognized session id format'
-                self.session_id = self.serialized[39:71]
-                remainder = self.serialized[71:]
-            else: 
-                remainder = self.serialized[39:]
-                self.session_id = None
-            
-            self.cipher_suite = ba2int(remainder[0:2])
-            assert self.cipher_suite in tlsn_cipher_suites.keys() , \
-                'Server chosen cipher suite not in TLS Notary allowed list, it was: '+str(self.cipher_suite)
-            assert remainder[2:] == '\x00', \
-                   'Received invalid server hello compression method'
-            #At end of serialized instantiation, we have defined server
-            #random and cipher suite
-        else:
-            print ('Not implemented instantiation of server hello',
-                   'without serialization; this is a client-only ',
-                   'TLS implementation')
+        assert serialized, """Not implemented instantiation of server hello
+                             without serialization; this is a client-only
+                              TLS implementation"""
+
+        super(TLSServerHello,self).__init__(serialized,h_sh)
+        self.tlsver = self.serialized[4:6]
+        self.server_random = self.serialized[6:38]
+        self.session_id_length = ba2int(self.serialized[38])
+        if self.session_id_length != 0:
+            if not self.session_id_length == 32:
+                raise TLSNSSLError('Server hello contains unrecognized session id format',
+                                   self.serialized[38])
+            self.session_id = self.serialized[39:71]
+            remainder = self.serialized[71:]
+        else: 
+            remainder = self.serialized[39:]
+            self.session_id = None
+        
+        self.cipher_suite = ba2int(remainder[0:2])
+        if not self.cipher_suite in tlsn_cipher_suites.keys():
+            raise TLSNSSLError('Server chosen cipher suite not in TLS Notary allowed list: ',
+                               str(self.cipher_suite))
+        if not remainder[2:] == '\x00':
+            raise TLSNSSLError('Received invalid server hello compression method',remainder[2:])
+        #At end of serialized instantiation, we have defined server
+        #random and cipher suite
+
 
 class TLSCertificate(TLSHandshake):
     def __init__(self, serialized = None):
-        if serialized:
-            super(TLSCertificate,self).__init__(serialized,h_cert)
-            #TODO we are currently reading *only* the first certificate
-            #in the list (tlsnotary code compares this with the browser
-            #as a re-use of browser PKI). It may be necessary to do a 
-            #more detailed parsing.
-            #This handshake message has format: hs_cert(1), hs_msg_len(3),
-            #certs_list_msg_len(3), [cert1_msg_len(3), cert1, cert_msg_len(3), cert2...]
-            #so the first cert data starts at byte position 10 
-            self.cert_len = ba2int(self.serialized[7:10])
-            self.asn1cert = self.serialized[10:10+self.cert_len]
+        assert serialized, """'Not implemented instantiation of certificate
+                   without serialization; this is a client-only
+                   TLS implementation"""
+
+        super(TLSCertificate,self).__init__(serialized,h_cert)
+        #TODO we are currently reading *only* the first certificate
+        #in the list (tlsnotary code compares this with the browser
+        #as a re-use of browser PKI). It may be necessary to do a 
+        #more detailed parsing.
+        #This handshake message has format: hs_cert(1), hs_msg_len(3),
+        #certs_list_msg_len(3), [cert1_msg_len(3), cert1, cert_msg_len(3), cert2...]
+        #so the first cert data starts at byte position 10 
+        self.cert_len = ba2int(self.serialized[7:10])
+        self.asn1cert = self.serialized[10:10+self.cert_len]
             
-        else:
-            print ('Not implemented instantiation of certificate',
-                   'without serialization; this is a client-only ',
-                   'TLS implementation')
             
 class TLSServerHelloDone(TLSHandshake):
     def __init__(self, serialized = None):
-            if serialized:
-                super(TLSServerHelloDone,self).__init__(serialized,h_shd)
-            else:
-                print ('Not implemented instantiation of server hello done',
-                       'without serialization; this is a client-only ',
-                       'TLS implementation')    
-
+        assert serialized, """Not implemented instantiation of server hello done
+                       without serialization; this is a client-only 
+                       TLS implementation"""
+        super(TLSServerHelloDone,self).__init__(serialized,h_shd)
+        
 class TLSClientKeyExchange(TLSHandshake):
     def __init__(self, serialized = None, encryptedPMS=None):
-        if serialized:
-            print ('Not implemented instantiation of client key exchange', 
-                        'with serialization; this is a client-only',
-                        ' TLS implementation')            
-        else:
-            if type(encryptedPMS) == type(long()):
-                self.encryptedPMS = bi2ba(encryptedPMS) #TODO zero byte bug?
-            #Note that the encpms is preceded by its 2-byte length
-            self.serialized = bi2ba(len(self.encryptedPMS),fixed=2) +self.encryptedPMS
-            super(TLSClientKeyExchange,self).__init__(None,h_cke)
-            super(TLSClientKeyExchange,self).serialize()
+        assert not serialized, """Not implemented instantiation of client key exchange
+                        with serialization; this is a client-only
+                        TLS implementation"""
+
+        if type(encryptedPMS) == type(long()):
+            self.encryptedPMS = bi2ba(encryptedPMS) #TODO zero byte bug?
+        #Note that the encpms is preceded by its 2-byte length
+        self.serialized = bi2ba(len(self.encryptedPMS),fixed=2) +self.encryptedPMS
+        super(TLSClientKeyExchange,self).__init__(None,h_cke)
+        super(TLSClientKeyExchange,self).serialize()
 
 
 class TLSChangeCipherSpec(object):
     def __init__(self,serialized=None):
         if serialized:
             self.serialized = serialized
-            assert self.serialized[0] == '\x01', 'Invalid change cipher spec received'
+            if not self.serialized[0] == '\x01':
+                raise TLSNSSLError('Invalid change cipher spec received',self.serialized[0])
             self.discarded = self.serialized[1:]
             self.serialized = self.serialized[0]
         else:
@@ -281,12 +296,12 @@ class TLSChangeCipherSpec(object):
         
 class TLSFinished(TLSHandshake):
     def __init__(self,serialized=None, verify_data=None):
-        if serialized: #process the server finished
+        if serialized: 
             super(TLSFinished,self).__init__(serialized,h_fin)
             self.validity = None
             self.verify_data = self.serialized[4:]
             
-        else: #create the client finished
+        else: 
             self.serialized = verify_data
             super(TLSFinished,self).__init__(None,h_fin)
             super(TLSFinished,self).serialize()
@@ -342,7 +357,8 @@ class TLSConnectionState(object):
         decrypted result is still made available.'''
         
         self.tlsver = tlsver #either TLS1.0 or 1.1
-        assert self.tlsver in tls_versions, "Unrecognised or invalid TLS version"
+        if not self.tlsver in tls_versions:
+            raise TLSNSSLError("Unrecognised or invalid TLS version", self.tlsver)
         self.cipher_suite = cipher_suite
         self.end = 'client' if is_client else 'server'
         self.mac_algo = md5 if cipher_suite == 4 else sha1
@@ -363,7 +379,8 @@ class TLSConnectionState(object):
     
     def build_record_mac(self, cleartext, record_type):
         seq_no_bytes = bi2ba(self.seq_no,fixed=8)
-        assert self.mac_key, "Failed to build mac; mac key is missing"
+        if not self.mac_key:
+            raise TLSNSSLError("Failed to build mac; mac key is missing")
         fragment_len = bi2ba(len(cleartext),fixed=2)  
         record_mac = hmac.new(self.mac_key,seq_no_bytes + record_type + \
                     self.tlsver+fragment_len + cleartext, self.mac_algo).digest()
@@ -545,11 +562,13 @@ class TLSNClientSession(object):
         while len(handshake_objects) < 3:
             rspns = recv_socket(sckt,True)
             records, remaining = tls_record_decoder(rspns)
-            assert not remaining, "Server sent spurious non-TLS response"
+            if remaining:
+                raise TLSNSSLError("Server sent spurious non-TLS response", remaining[:20])
             for rec in records:
                 handshake_objects.extend(tls_record_fragment_decoder(hs,rec.fragment))
-        assert [h_sh,h_cert,h_shd] == [x.handshake_type for x in handshake_objects], \
-               "Server failed to send server hello, certificate, server hello done"
+        if not [h_sh,h_cert,h_shd] == [x.handshake_type for x in handshake_objects]:
+               raise TLSNSSLError("Server failed to send server hello, certificate, server hello done",
+                                  ''.join([x.handshake_type for x in handshake_objects]))
         self.server_hello, self.server_certificate, self.server_hello_done = handshake_objects
         
         self.handshake_messages[1:4] = [x.serialized for x in handshake_objects]
@@ -566,7 +585,7 @@ class TLSNClientSession(object):
                 #TODO: error checking to make sure this is the case.
                 self.tlsver = bytearray('\x03\x01')
             else:
-                raise Exception("Failed to negotiate valid TLS version with server")
+                raise TLSNSSLError("Failed to negotiate valid TLS version with server",self.server_hello.tlsver)
         
         #for 'full' sessions, we can immediately precompute everything except
         #for finished, including the handshake hashes used to calc the Finished
@@ -585,8 +604,8 @@ class TLSNClientSession(object):
         if not provided_p_value:
             #we calculate the verify data from the raw handshake messages
             if self.handshake_messages[:6] != filter(None,self.handshake_messages[:6]):
-                print ('Here are the handshake messages: ',[str(x) for x in self.handshake_messages[:6]])
-                raise Exception('Handshake data was not complete, could not calculate verify data')
+                #whole handshake is too big to print here; will be seen in debug dump.
+                raise TLSNSSLError('Handshake data was not complete, could not calculate verify data')
             label = 'client finished' if is_for_client else 'server finished'
             seed = md5_verify + sha_verify
             ms = self.master_secret_half_auditor+self.master_secret_half_auditee
@@ -629,7 +648,8 @@ class TLSNClientSession(object):
         while len(records) < 2: #conceivably, might want an extra timeout for naughty servers!?
             rspns = recv_socket(sckt,True)
             x, remaining = tls_record_decoder(rspns)
-            assert not remaining, "Server sent spurious non-TLS response"
+            if remaining:
+                raise TLSNSSLError("Server sent spurious non-TLS response", remaining[:20])
             records.extend(x)
         
         #this strange-looking 'filtering' approach is based on observation
@@ -640,7 +660,8 @@ class TLSNClientSession(object):
         self.server_finished = tls_record_fragment_decoder(hs,sf.fragment, \
                                                     conn=self.server_connection_state, \
                                                     ignore_mac=True)[0]
-        assert self.server_finished.handshake_type == h_fin, "Server failed to send Finished" 
+        if not self.server_finished.handshake_type == h_fin:
+            raise TLSNSSLError("Server failed to send Finished" , self.server_finished.handshake_type)
         #store the IV immediately after decrypting Finished; this will be needed
         #by auditor in order to replay the decryption
         self.IV_after_finished = self.server_connection_state.IV 
@@ -651,7 +672,7 @@ class TLSNClientSession(object):
                 if x.content_type in [chcis,hs]: continue
                 if x.content_type != appd:
                     #this is too much; if it's an Alert or something, we give up.
-                    raise Exception("Received unexpected TLS record before client request.")
+                    raise TLSNSSLError("Received unexpected TLS record before client request.", x.content_type)
                 #store any app data records, in sequence, prior to processing all app data.
                 self.server_response_app_data.extend(tls_record_fragment_decoder(appd,x.fragment))
                 #We have to store the raw form of these unexpected app data records, since they will
@@ -721,14 +742,15 @@ class TLSNClientSession(object):
         return (self.server_modulus,self.server_exponent)  
         
     def set_encrypted_pms(self):
-        assert (self.enc_first_half_pms and self.enc_second_half_pms and self.server_modulus), \
-            'failed to set enc_pms, first half was: ' + str(self.enc_first_half_pms) +\
-            ' second half was: ' + str(self.enc_second_half_pms) + ' modulus was: ' + str(self.server_modulus)
+        if not (self.enc_first_half_pms and self.enc_second_half_pms and self.server_modulus):
+            raise TLSNSSLError("Failed to set encpms")
+            
         self.enc_pms =  self.enc_first_half_pms * self.enc_second_half_pms % self.server_modulus
         return self.enc_pms
 
     def set_enc_first_half_pms(self):
-        assert (self.server_modulus and not self.enc_first_half_pms)
+        if not (self.server_modulus and not self.enc_first_half_pms):
+            raise TLSNSSLError("Failed to set enc first half pms")
         ones_length = 23            
         self.pms1 = self.initial_tlsver+self.auditee_secret + ('\x00' * (24-2-self.n_auditee_entropy))
         self.enc_first_half_pms = pow(ba2int('\x02'+('\x01'*(ones_length))+\
@@ -744,7 +766,8 @@ class TLSNClientSession(object):
         tlsver_ch = self.initial_tlsver
         cr = self.client_random
         sr = self.server_random
-        assert cr and sr,"one of client or server random not set"
+        if not cr and sr:
+            raise TLSNSSLError("one of client or server random not set")
         if not self.auditee_secret:
             self.auditee_secret = os.urandom(self.n_auditee_entropy)             
         if not self.auditee_padding_secret:
@@ -757,7 +780,8 @@ class TLSNClientSession(object):
         return (self.p_auditee)
 
     def set_enc_second_half_pms(self):
-        assert (self.server_modulus)
+        if not self.server_modulus:
+            raise TLSNSSLError("Failed to set enc second half pms")
         ones_length = 103+ba2int(self.server_mod_length)-256
         self.pms2 =  self.auditor_secret + ('\x00' * (24-self.n_auditor_entropy-1)) + '\x01'
         self.enc_second_half_pms = pow( ba2int('\x01'+('\x01'*(ones_length))+\
@@ -770,7 +794,8 @@ class TLSNClientSession(object):
         'secret' should be a bytearray of length n_auditor_entropy'''
         cr = self.client_random
         sr = self.server_random
-        assert cr and sr, "one of client or server random not set"
+        if not cr and sr:
+            raise TLSNSSLError("one of client or server random not set")
         if not self.auditor_secret:
             self.auditor_secret = os.urandom(self.n_auditor_entropy)
         if not self.auditor_padding_secret:
@@ -790,7 +815,8 @@ class TLSNClientSession(object):
             return self.master_secret_half_auditor+self.master_secret_half_auditee
         assert half in [1,2], "Must provide half argument as 1 or 2"
         #otherwise the p value must be enough to provide one half of MS
-        assert len(provided_p_value)==24, "Wrong length of P-hash value for half MS setting."
+        if not len(provided_p_value)==24:
+            raise TLSNSSLError("Wrong length of P-hash value for half MS setting.", provided_p_value)
         if half == 1:
             self.master_secret_half_auditor = xor(self.p_auditor[:24],provided_p_value)
             return self.master_secret_half_auditor
@@ -803,8 +829,8 @@ class TLSNClientSession(object):
         that key from the counterparty, in the array 'garbage', each number is
         an index to that key in the cipher_suites dict        
         '''
-        assert (self.server_random and self.client_random and self.chosen_cipher_suite), \
-               "server random, client random or cipher suite not set."
+        if not (self.server_random and self.client_random and self.chosen_cipher_suite):
+            raise TLSNSSLError("server random, client random or cipher suite not set.")
         label = 'key expansion'
         seed = self.server_random + self.client_random
         expkeys_len = tlsn_cipher_suites[self.chosen_cipher_suite][-1]        
@@ -836,7 +862,8 @@ class TLSNClientSession(object):
         cr = self.client_random
         sr = self.server_random
         cs = self.chosen_cipher_suite
-        assert cr and sr and cs," need client and server random and cipher suite"
+        if not cr and sr and cs:
+            raise TLSNSSLError("need client and server random and cipher suite")
         label = 'key expansion'
         seed = sr + cr
         #for maximum flexibility, we will compute the sha1 or md5 hmac
@@ -853,7 +880,7 @@ class TLSNClientSession(object):
         elif self.p_master_secret_auditee and self.p_master_secret_auditor:
             key_expansion = xor(self.p_master_secret_auditee,self.p_master_secret_auditor)
         else:
-            raise Exception ('Cannot expand keys, insufficient data')
+            raise TLSNSSLError('Cannot expand keys, insufficient data')
 
         #we have the raw key expansion, but want the keys. Use the data
         #embedded in the cipherSuite dict to identify the boundaries.
@@ -894,8 +921,10 @@ class TLSNClientSession(object):
                                                 provided_p_value=provided_p_value,
                                                 half=2,
                                                 is_for_client=False)
-        assert self.server_finished.verify_data == verify_data_check, \
-               "Server Finished record verify data is not valid."        
+        if not self.server_finished.verify_data == verify_data_check:
+            raise TLSNSSLError("Server Finished record verify data is not valid.", 
+                               self.server_finished.verify_data+verify_data_check)
+        
         return True        
 
     def build_request(self, sckt, cleartext):
@@ -910,7 +939,8 @@ class TLSNClientSession(object):
         #extract the ciphertext from the raw records as a list
         #for maximum flexibility in decryption
         recs, remaining = tls_record_decoder(response)
-        assert not remaining, "Server sent spurious non-TLS data"
+        if remaining:
+            raise TLSNSSLError("Server sent spurious non-TLS data", remaining[:20])
         for rec in recs:
             self.server_response_app_data.extend(tls_record_fragment_decoder(rec.content_type,
                                                                              rec.fragment))    
@@ -922,7 +952,7 @@ class TLSNClientSession(object):
         '''for use with aes-js'''   
         assert len(self.server_response_app_data),"Could not process the server response, no ciphertext found."
         if not self.chosen_cipher_suite in [47,53]: #AES-CBC
-            raise Exception("non-AES cipher suite.")                    
+            raise TLSNSSLError("non-AES cipher suite.", bi2ba(self.chosen_cipher_suite))                    
         ciphertexts = [] #each item contains a tuple (ciphertext, encryption_key, iv)
         last_ciphertext_block = self.IV_after_finished
         for appdata in self.server_response_app_data:
@@ -952,7 +982,7 @@ class TLSNClientSession(object):
         dummy_connection_state.verify_mac(self.server_finished.serialized+\
                                           self.server_finished.recorded_mac,hs)
         if not validity:
-            raise Exception ("Server finished mac check failed")
+            raise TLSNSSLError("Server finished mac check failed", self.server_finished.recorded_mac)
         #NB Note the verify data was verified earlier, no need to do it again here
         for i,pt in enumerate(plaintexts):
             if type(self.server_response_app_data[i]) is TLSAppData:
@@ -964,7 +994,8 @@ class TLSNClientSession(object):
                        type(self.server_response_app_data[i]))
                
             validity, stripped_pt = dummy_connection_state.verify_mac(pt,rt)
-            assert validity==True, "Fatal error - invalid mac, data not authenticated!"
+            if not validity:
+                raise TLSNSSLError("Fatal error - invalid mac, data not authenticated!",pt[:20])
             
             #plaintext is only included if it's appdata not alerts, and if it's 
             #not part of the ignored set (the set that was delivered pre-client-request)            
@@ -1006,8 +1037,8 @@ class TLSNClientSession(object):
             self.server_connection_state.seq_no += 1
             self.server_connection_state.IV = self.IV_after_finished
             
-        assert len(self.server_response_app_data),\
-        "Could not process the server response, no ciphertext found."
+        if not len(self.server_response_app_data):
+            raise TLSNSSLError("Could not process the server response, no ciphertext found.")
         plaintexts = ''
         for i,ciphertext in enumerate(self.server_response_app_data):
             if type(ciphertext) is TLSAppData:
@@ -1015,7 +1046,7 @@ class TLSNClientSession(object):
             elif type(ciphertext) is TLSAlert:
                 rt = alrt
             else:
-                raise Exception ("Server response contained unexpected record type: ", type(ciphertext))
+                raise TLSNSSLError("Server response contained unexpected record type ")
             validity, plaintext = self.server_connection_state.dtvm(ciphertext.serialized,rt)
             if not validity==True: 
                 bad_record_mac += 1
@@ -1037,7 +1068,7 @@ def cbc_unpad(pt):
     pad_len = ba2int(pt[-1])
     #verify the padding
     if not all(pad_len == x for x in map(ord,pt[-pad_len-1:-1])):
-        raise Exception ("Invalid CBC padding.")
+        raise TLSNSSLError("Invalid CBC padding.", pt)
     return pt[:-(pad_len+1)]    
                     
 def rc4_crypt(data, key, state=None):
@@ -1091,11 +1122,11 @@ def tls_10_prf(seed, req_bytes = 48, first_half=None,second_half=None,full_secre
     '''
     #sanity checks, (see choices of how to provide secrets under 'Notes' above)
     if not first_half and not second_half and not full_secret:
-        raise Exception("Error in TLSPRF: at least one half of the secret is required.")
+        raise TLSNSSLError("Error in TLSPRF: at least one half of the secret is required.")
     if (full_secret and first_half) or (full_secret and second_half):
-        raise Exception("Error in TLSPRF: both full and half secrets should not be provided.")
+        raise TLSNSSLError("Error in TLSPRF: both full and half secrets should not be provided.")
     if first_half and second_half:
-        raise Exception("Error in TLSPRF: please provide the secret in the parameter full_secret.")
+        raise TLSNSSLError("Error in TLSPRF: please provide the secret in the parameter full_secret.")
 
     P_MD5 = P_SHA_1 = PRF = None
 


### PR DESCRIPTION
A standardised exception for the TLS code; includes a hexlified data information component in the error message.

Apart from clearing out inappropriate asserts, the intention here is to allow catching this exception as a flag to tell the cleanup code to do a tlsn_session.dump() to file on error to help with debugging. This second phase I haven't done yet, I think it will take a while to figure out.

Tested against the full 30 site list. All went correctly except I got a strange error on delicious.com (but wasn't repeatable). 