### PR TITLE
auditee side TLS exception handling with session dumps

### DIFF
--- a/src/shared/tlsn_ssl.py
+++ b/src/shared/tlsn_ssl.py
@@ -73,9 +73,17 @@ class TLSNSSLError(Exception):
             self.data = binascii.hexlify(data)
         else:
             self.data = ''
-    
+            
     def __str__(self):
-        return self.msg + ': ' + self.data
+            return self.msg + ': ' + self.data    
+
+def ssl_dump(session, fn=None):
+    #Note that this dump write could be encapsulated
+    #in the TLSNSSLError class, but the session object
+    #is not always available in context.
+    filename = 'ssldump' if not fn else fn
+    with open(filename,'wb') as f:
+        f.write(session.dump())    
     
 def tls_record_decoder(d):
     '''Given a binary data stream d,


### PR DESCRIPTION
Basically, catching TLSNSSLError exceptions during auditee processing and writing out a session dump to disk.
In cases where there are 10 retries, abort immediately for this particular exception and count it as an audit failure.

Also, where we are dealing with two different TLSNSSLClientSession objects (in prepare_pms), dump both those session states.

This combined with the previous commit should give clearer error messages and help with debugging.

The already-mentioned issue of getting the http request doubled (so start_audit is called twice) isn't solved - I still don't know why that happens.

Obviously this should be extended to auditor side; it could be another commit/PR.